### PR TITLE
Async mode

### DIFF
--- a/accounts.js
+++ b/accounts.js
@@ -30,7 +30,7 @@ EthAccounts._watchBalance = function(){
     var _this = this;
 
     if(this.blockSubscription) {
-        this.blockSubscription.stopWatching();
+        this.blockSubscription.stopWatching(function(e, res){console.log(e, res);});
     }
 
     // UPDATE SIMPLE ACCOUNTS balance on each new block


### PR DESCRIPTION
Without this change, Metamask will send an error because it is not working with sync mode.